### PR TITLE
feat(issue-2): add date & price to upcoming events

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,14 @@
             line-height: 1.5em;
         }
 
+         .event-card .event-meta {
+   font-size: 0.9rem;
+   color: #0077ff;
+   font-weight: bold;
+   padding: 5px 0;
+   min-height: 1.5em;
+  }
+
         .event-card a.button {
             margin: 10px;
             padding: 10px 15px;
@@ -193,6 +201,7 @@
                     </div>
                 </a>
                 <h3>Wine Appreciation</h3>
+                 <div class="event-meta">$10 | 25 Dec 2025</div>
                 <div class="description">Join us for an afternoon of wine tasting and networking</div>
                 <a href="https://go.gov.sg/bvwineappr2025" class="button">Sign up</a>
             </div>
@@ -206,6 +215,7 @@
                     </div>
                 </a>
                 <h3>Join our Telegram</h3>
+                 <div class="event-meta">Free | Always Open</div>
                 <div class="description">Be notified of all our latest events and programmes!</div>
                 <a href="https://go.gov.sg/bvyntele" class="button">Subscribe</a>
             </div>


### PR DESCRIPTION
Added date and price display to upcoming event cards:
- Added .event-meta CSS class with blue color and bold font
- Added event metadata div to Wine Appreciation event: "$10 | 25 Dec 2025"
- Added event metadata div to Telegram event: "Free | Always Open"
- Metadata displays between event title and description

This addresses issue #2 by displaying pricing and date information prominently on each event card.

Fixes #2